### PR TITLE
Fix url for util.api.search

### DIFF
--- a/lib/resources/project.js
+++ b/lib/resources/project.js
@@ -745,7 +745,7 @@ function _callbackWithSearchResults(error, res, cb) { // cb(error, results)
         stories: []
     };
 
-    if (!error && res && Array.isArray(res.data) && res.data.length) {
+    if (!error && res && res.data) {
 
         var epics = null;
         var stories = null;

--- a/lib/resources/utils.js
+++ b/lib/resources/utils.js
@@ -2,7 +2,8 @@
 var FormData = require('form-data'),
     request = require('request'),
     fs = require('fs'),
-    util = require('util');
+    util = require('util'),
+    apiCall, originalApiCall;
 
 function get(token, pathSegments, query, options, cb) {
     apiCall('GET', token, pathSegments, query, null, options, cb);
@@ -27,10 +28,9 @@ function search(token, pathSegments, query, options, cb) {
         q = query;
     }
     else if (typeof query === 'string') {
-        q = {
-            query: _queryObjToStr(query)
-        };
+        q = { query: query };
     }
+    pathSegments.push('search');
     apiCall('GET', token, pathSegments, q, null, options, cb);
 }
 
@@ -101,7 +101,9 @@ function ApiError(status, data) {
 ApiError.prototype = new Error();
 ApiError.prototype.constructor = ApiError;
 
-function apiCall(method, token, pathSegments, query, data, opts, cb) {
+apiCall =
+    originalApiCall =
+function (method, token, pathSegments, query, data, opts, cb) {
 
     var path = Array.isArray(pathSegments) ? pathSegments.join('/') : '';
 
@@ -173,7 +175,7 @@ function apiCall(method, token, pathSegments, query, data, opts, cb) {
             cb(null, _cleanInbound(body));
         }
     });
-}
+};
 
 function _cleanInbound(obj) {
 
@@ -432,6 +434,11 @@ exports.api = {
     search   : search,
     upload   : upload,
     download : download
+};
+
+exports.tests_ = {
+    stubApiCall    : function (newMethod) { apiCall = newMethod; },
+    restoreApiCall : function () { apiCall = originalApiCall; }
 };
 
 exports.toError = _toError;

--- a/tests/unit/run.js
+++ b/tests/unit/run.js
@@ -11,5 +11,6 @@ module.exports = {
     "test-resource-projectmembership": require('./test-resource-projectmembership.js'),
     "test-resource-story": require('./test-resource-story.js'),
     "test-resource-task": require('./test-resource-task.js'),
+    "test-resource-utils": require('./test-utils.js'),
     "test-tracker": require('./test-tracker.js')
 };

--- a/tests/unit/test-utils.js
+++ b/tests/unit/test-utils.js
@@ -1,0 +1,26 @@
+var nodeunit = require('nodeunit'),
+    utils = require('../../lib/resources/utils');
+
+exports.test_search = function(test) {
+    test.expect(2);
+
+    var actualPathSegments,
+        actualQuery,
+        apiCall = function (method, token, pathSegments, query, data, opts, cb) {
+            actualPathSegments = pathSegments;
+            actualQuery = query;
+        };
+
+    utils.tests_.stubApiCall(apiCall);
+    utils.api.search("TestToken",
+      ["services", "v5", "projects", "101"],
+      "fred",
+      { },
+      function () { });
+
+    test.equal("search", actualPathSegments[actualPathSegments.length - 1], "Path should end in 'search'");
+    test.equal("fred", actualQuery.query, "URL query sement should have search string");
+
+    utils.tests_.restoreApiCall();
+	test.done();
+};


### PR DESCRIPTION
We saw that search didn't work because it was running _queryObjToString on a string.