### PR TITLE
task Service called with missing params

### DIFF
--- a/lib/resources/story.js
+++ b/lib/resources/story.js
@@ -441,7 +441,7 @@ Service.prototype.label = function(labelId) {
 };
 
 Service.prototype.task = function(taskId) {
-       return new task.Service(this.config, this.projectId, this.storyId, taskId);
+       return new task.Service(this.config, 'story', this.projectId, this.storyId, taskId);
 };
 
 Service.prototype.all = function(options, cb) { // cb(err, stories[])

--- a/lib/resources/task.js
+++ b/lib/resources/task.js
@@ -120,10 +120,10 @@ Task.prototype.inspect = function() {
     return ptutil.inspect(this);
 };
 
-function Service(config, projectId, storyId, taskId) {
+function Service(config, taskType, projectId, storyId, taskId) {
     
     if (!(this instanceof Service)){
-        return new Service(config, projectId, storyId, taskId);
+        return new Service(config, taskType, projectId, storyId, taskId);
     }
     
     config = config || {};
@@ -135,6 +135,12 @@ function Service(config, projectId, storyId, taskId) {
             configurable: false,
             writable: false,
             value: config
+        },
+        "taskType": {
+            enumerable: false,
+            configurable: false,
+            writable: false,
+            value: taskType
         },
         "projectId": {
             enumerable: true,


### PR DESCRIPTION
Fixing issue https://github.com/generalui/pivotaltracker/issues/10

## What is this?

Previously, a user could not attach a new task to an existing story because there were missing arguments when setting up the `task.Service` in `resources/story.js`. This PR fixes the inconsistency by replicating the `Service` constructor signature from `comment.js` and `label.js`. Now you should be able to create tasks with the expected pathing. yay!

## How to test
Try to add a task to an existing story. Does it work?
```
client.project(projectId).story(storyId).tasks.create({description: "some task"}, function (err, task) {
    // works now!
});
```