### PR TITLE
fix stories.all, return all stories

### DIFF
--- a/lib/resources/story.js
+++ b/lib/resources/story.js
@@ -2,8 +2,8 @@
     Source, Story resource structure:
     https://www.pivotaltracker.com/help/api/rest/v5#story_resource
 */
-
-var activity = require('./activity'),
+var merge = require('lodash.merge'),
+    activity = require('./activity'),
     comment = require('./comment'),
     label = require('./label'),
     task = require('./task'),
@@ -445,24 +445,56 @@ Service.prototype.task = function(taskId) {
 };
 
 Service.prototype.all = function(options, cb) { // cb(err, stories[])
+    var defaultOptions = {  
+        limit: 500, 
+        offset: 0 
+    };
     if (typeof options === 'function' && typeof cb === 'undefined') {
         cb = options;
-        options = null; // options is an optional param
+        options = {}; // options is an optional param
     }
 
-    if (!this.projectId) {
-        cb(new Error('Invalid project ID'), null);
-    }
-    else {
-        ptutil.api.get(
+    options = merge(defaultOptions, options);
+    var allStories = []
+    
+    function getStories (allStories) {
+        var _this = this;
+
+        return ptutil.api.get(
             this.config.trackerToken,
             this.pathSegments(),
             options, // query
             this.config, // options
             function(error, res) {
-                _callbackWithStories(error, res, cb);
+                if(error) {
+                    return cb(error);
+                 }
+
+                if (!error && res && Array.isArray(res.data) && res.data.length) {
+                    res.data.forEach(function(ele) {
+                        allStories.push(new Story(ele));
+                    });
+                }
+
+                if(res.data.length <= 0) {
+                   return cb(null, allStories);
+                }
+
+                // recursion in 500 batches, currently there's no way to tell how many piv stories in total
+                options.limit+=500;
+                options.offset+=500;
+                getStories.call(_this, allStories);
             });
+    };
+
+   
+    if (!this.projectId) {
+        cb(new Error('Invalid project ID'), null);
+    } else {
+        return getStories.call(this, allStories);
     }
+
+    
 };
 
 Service.prototype.get = function(cb) { // cb(err, story)
@@ -558,21 +590,6 @@ function _callbackWithStory(error, res, cb) {
     }
 
     cb(error, result);
-}
-
-function _callbackWithStories(error, res, cb) {
-
-    var arr = [];
-
-    if (!error && res && Array.isArray(res.data) && res.data.length) {
-
-        res.data.forEach(function(ele) {
-
-            arr.push(new Story(ele));
-        });
-    }
-
-    cb(error, arr);
 }
 
 function _serviceToString() {

--- a/package.json
+++ b/package.json
@@ -38,8 +38,9 @@
     "test": "nodeunit ./tests/unit/run.js"
   },
   "dependencies": {
-    "request": "2.33.x",
-    "form-data": "~0.1.2"
+    "form-data": "~0.1.2",
+    "lodash.merge": "^4.6.0",
+    "request": "2.33.x"
   },
   "devDependencies": {
     "nodeunit": "latest",


### PR DESCRIPTION
Piv REST API v5 limits has pagination by default 
https://www.pivotaltracker.com/help/api#Paginating_List_Responses 

It also restrict to maximum result set of 500 entries.

Therefore it was required to call the api recursively to fetch all stories

solves #20 