### PR TITLE
Add single iteration, fluent-implementation to project resource

### DIFF
--- a/examples/get-iterations.js
+++ b/examples/get-iterations.js
@@ -1,31 +1,63 @@
 /**
     To run from command line:
 
-    node get-iteration username password projectId
+    node get-iterations username password projectId [iterationId [query]]
+
+    ex. 1. All Iterations
+      $ node get-iterations 'user' 'password' 12345
+
+    ex. 2. Single Iteration
+      $ node get-iterations 'user' 'password' 12345 3
+
+    ex. 3. Single Iteration with Query (to append query string params to api call)
+      $ node get-iterations 'user' 'password' 12345 3 '{"fields":"kind"}'
 
     https://www.pivotaltracker.com/help/api/rest/v5#Iterations
-*/
+    https://www.pivotaltracker.com/help/api/rest/v5#projects_project_id_iteration_get
+ */
 var tracker  = require("../index.js"),
-    username = process.argv[2],
-    password = process.argv[3],
-    projectId = process.argv[4];
+  username = process.argv[2],
+  password = process.argv[3],
+  projectId = process.argv[4],
+  iterationId = process.argv[5],
+  query = process.argv[6];
 
 tracker.getToken(username, password, function(err, token) {
 
-    if(err){
-        console.error("Could not retrieve token");
-        console.log(err);
+  if(err){
+    console.error("Could not retrieve token");
+    console.log(err);
+  }
+  else {
+    var client = new tracker.Client({trackerToken:token});
+    var projectSubQuery = client.project(projectId);
+
+    if (iterationId) {
+      if (!query) {
+          query = {};
+      }
+      else if ('string' === typeof(query)) {
+          query = JSON.parse(query);
+      }
+
+      projectSubQuery.iteration(iterationId).get(query, function(error, iteration) {
+        if (error) {
+          console.log(error);
+        }
+        else {
+          console.log(iteration);
+        }
+      });
     }
     else {
-        var client = new tracker.Client({trackerToken:token});
-
-        client.project(projectId).iterations.all(function(error, iterations) {
-            if (error) {
-                console.log(error);
-            }
-            else {
-                console.log(iterations);
-            }
-        });
+      projectSubQuery.iterations.all(function(error, iterations) {
+        if (error) {
+          console.log(error);
+        }
+        else {
+          console.log(iterations);
+        }
+      });
     }
+  }
 });

--- a/lib/resources/iteration.js
+++ b/lib/resources/iteration.js
@@ -142,7 +142,7 @@ Iteration.prototype.inspect = function() {
     return ptutil.inspect(this);
 };
 
-function Service(config, projectId) {
+function Service(config, projectId, iterationId) {
     
     if (!(this instanceof Service)){
         return new Service(config, projectId);
@@ -163,6 +163,12 @@ function Service(config, projectId) {
             configurable: false,
             writable: false,
             value: ptutil.intOrNull(projectId)
+        },
+        "iterationId": {
+            enumerable: true,
+            configurable: false,
+            writable: false,
+            value: ptutil.intOrNull(iterationId)
         }
     });
     
@@ -173,7 +179,7 @@ Service.prototype.inspect = function() {
     return ptutil.inspect(this);
 };
 
-Service.prototype.all = function(cb) { // cb(err, tasks[])
+Service.prototype.all = function(cb) { // cb(err, iterations[])
     var err = this.configError();
     if (err) {
         cb(err, null);
@@ -190,13 +196,43 @@ Service.prototype.all = function(cb) { // cb(err, tasks[])
     }
 };
 
+Service.prototype.get = function(query, cb) { // cb(err, iteration)
+  if (!this.projectId) {
+    cb(new Error('Invalid project ID'), null);
+  }
+  else if (!this.iterationId) {
+    cb(new Error('Invalid iteration ID'), null);
+  }
+  else {
+    if ('function' === typeof query) {
+        cb = query;
+        query = null;
+    }
+
+    ptutil.api.get(
+      this.config.trackerToken,
+      this.pathSegments(),
+      query,
+      this.config, //options
+      function(error, res) {
+        _callbackWithIteration(error, res, cb);
+      });
+  }
+};
+
 Service.prototype.pathSegments = function() {
     /*
     
-    /projects/{project_id}/iterations
+    /projects/{project_id}/iterations[/{iteration_id}]
     
     */
-    return ['projects',this.projectId,'iterations'];
+    var segments = ['projects',this.projectId,'iterations'];
+
+    if (typeof this.iterationId === 'number') {
+        segments.push(this.iterationId);
+    }
+
+    return segments;
 };
 
 Service.prototype.configError = function() {
@@ -207,6 +243,17 @@ Service.prototype.configError = function() {
         return null;
     }
 };
+
+function _callbackWithIteration(error, res, cb) { // cb(error, iteration)
+
+  var result = null;
+
+  if (!error && res && res.data) {
+    result = new Iteration(res.data);
+  }
+
+  cb(error, result);
+}
 
 function _callbackWithIterations(error, res, cb) {
 

--- a/lib/resources/project.js
+++ b/lib/resources/project.js
@@ -594,6 +594,10 @@ Service.prototype.story = function(storyId) {
     return new story.Service(this.config, this.projectId, storyId);
 };
 
+Service.prototype.iteration = function(iterationId) {
+    return new iteration.Service(this.config, this.projectId, iterationId);
+};
+
 Service.prototype.search = function(filters, cb) { // cb(err, projects)
     if (!this.projectId) {
         cb(new Error('Invalid project ID'), null);


### PR DESCRIPTION
* Allow for requesting of a single iteration from a given project (avoid pulling all iterations)
* Allow for passing a query string when pulling a single iteration to negotiate response tokens
* Update *get-iterations* example to showcase functionality